### PR TITLE
feat: Add unit tests for BudgetService

### DIFF
--- a/src/app/services/budget.service.spec.ts
+++ b/src/app/services/budget.service.spec.ts
@@ -13,4 +13,77 @@ describe('BudgetService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  describe('initial state', () => {
+    it('should return 0 for budgetAsNumber', () => {
+      expect(service.budgetAsNumber()).toBe(0);
+    });
+
+    it('should return "0" for budgetAsString', () => {
+      expect(service.budgetAsString()).toBe('0');
+    });
+  });
+
+  describe('addTransaction', () => {
+    it('should update budget correctly for a single positive transaction', () => {
+      service.addTransaction(100);
+      expect(service.budgetAsNumber()).toBe(100);
+      expect(service.budgetAsString()).toBe('100');
+    });
+
+    it('should update budget correctly for a single negative transaction', () => {
+      service.addTransaction(100); // Initial positive transaction
+      service.addTransaction(-50);
+      expect(service.budgetAsNumber()).toBe(50);
+      expect(service.budgetAsString()).toBe('50');
+    });
+
+    it('should update budget correctly for multiple transactions', () => {
+      service.addTransaction(50);
+      service.addTransaction(-20);
+      service.addTransaction(30);
+      expect(service.budgetAsNumber()).toBe(60);
+      expect(service.budgetAsString()).toBe('60');
+    });
+  });
+
+  describe('resetTransactions', () => {
+    it('should reset budget to 0 when no argument is provided', () => {
+      service.addTransaction(100);
+      service.addTransaction(-50);
+      service.resetTransactions();
+      expect(service.budgetAsNumber()).toBe(0);
+      expect(service.budgetAsString()).toBe('0');
+    });
+
+    it('should reset budget to the provided value', () => {
+      service.addTransaction(50);
+      service.addTransaction(20);
+      service.resetTransactions(75);
+      expect(service.budgetAsNumber()).toBe(75);
+      expect(service.budgetAsString()).toBe('75');
+    });
+  });
+
+  describe('negative budget', () => {
+    it('should handle initial negative budget correctly', () => {
+      service.resetTransactions(-100);
+      expect(service.budgetAsNumber()).toBe(-100);
+      expect(service.budgetAsString()).toBe('0');
+    });
+
+    it('should handle positive transaction that results in a negative budget correctly', () => {
+      service.resetTransactions(-100);
+      service.addTransaction(50);
+      expect(service.budgetAsNumber()).toBe(-50);
+      expect(service.budgetAsString()).toBe('0');
+    });
+
+    it('should handle positive transaction that results in a positive budget correctly', () => {
+      service.resetTransactions(-50);
+      service.addTransaction(70);
+      expect(service.budgetAsNumber()).toBe(20);
+      expect(service.budgetAsString()).toBe('20');
+    });
+  });
 });


### PR DESCRIPTION
This commit introduces comprehensive unit tests for the `BudgetService`. The tests cover the following functionalities:

- Initial state of the budget.
- Adding positive, negative, and multiple transactions.
- Resetting transactions with and without an initial value.
- Behavior of computed signals (`budgetAsNumber` and `budgetAsString`) when the budget is negative, ensuring `budgetAsString` correctly returns "0" for negative budgets.