### PR TITLE
Fix history date parsing and withdrawal input

### DIFF
--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -14,7 +14,7 @@ export class StorageService {
     try {
       localStorage.setItem(key, JSON.stringify(value));
     } catch (error) {
-      console.error('Error parsing value for key:', key, error);
+      console.error('Error serializing value for key:', key, error);
       return;
     }
   }

--- a/src/app/services/withdrawal-amount.service.ts
+++ b/src/app/services/withdrawal-amount.service.ts
@@ -40,8 +40,11 @@ export class WithdrawalAmountService {
    */
   pop(): number {
     const prevAmount = this.amountAsNumber();
-    if (this.amountAsNumber() > 0) {
-      this.amount.update((prev) => prev.slice(0, -1));
+    if (prevAmount > 0) {
+      this.amount.update((prev) => {
+        const next = prev.slice(0, -1);
+        return next.length > 0 ? next : '0';
+      });
       return prevAmount - this.amountAsNumber();
     }
     return 0;

--- a/src/app/services/withdrawal-history.service.ts
+++ b/src/app/services/withdrawal-history.service.ts
@@ -18,11 +18,13 @@ export class WithdrawalHistoryService {
   private storageService = inject(StorageService);
 
   readonly historyItems = computed<Withdrawal[]>(() => {
-    return this.transactions()
-      .sort((a, b) => (isBefore(a.dateTime, b.dateTime) ? 1 : -1))
+    return [...this.transactions()]
+      .sort((a, b) =>
+        isBefore(new Date(a.dateTime), new Date(b.dateTime)) ? 1 : -1,
+      )
       .map((transaction) => ({
         ...transaction,
-        dateTime: format(transaction.dateTime, 'MMM d, HH:mm'),
+        dateTime: format(new Date(transaction.dateTime), 'MMM d, HH:mm'),
       }));
   });
 
@@ -39,6 +41,11 @@ export class WithdrawalHistoryService {
   }
 
   setTransactions(transactions: Withdrawal[]) {
-    this.transactions.set(transactions);
+    this.transactions.set(
+      transactions.map((t) => ({
+        ...t,
+        dateTime: new Date(t.dateTime),
+      })),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- prevent NaN in WithdrawalAmountService `pop`
- parse dates when loading withdrawal history
- avoid mutating history array
- fix error message in StorageService

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_6841ee3d148c83309b67d5aa6542deea